### PR TITLE
Fix flaky test in TestPutSplunkHTTP.java

### DIFF
--- a/nifi-nar-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestPutSplunkHTTP.java
+++ b/nifi-nar-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestPutSplunkHTTP.java
@@ -47,6 +47,8 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -131,7 +133,8 @@ public class TestPutSplunkHTTP {
 
         // then
         testRunner.assertAllFlowFilesTransferred(PutSplunkHTTP.RELATIONSHIP_SUCCESS, 1);
-        assertEquals("/services/collector/raw?sourcetype=test%3Fsource%3Ftype&source=test_source", path.getValue());
+        assertTrue("/services/collector/raw?source=test_source&sourcetype=test%3Fsource%3Ftype".equals(path.getValue()) ||"/services/collector/raw?sourcetype=test%3Fsource%3Ftype&source=test_source".equals( path.getValue()) );
+	
     }
 
     @Test


### PR DESCRIPTION
**Problem**
In the test TestPutSplunkHTTP#testHappyPathWithCustomQueryParameters, the path with the property is compared with a hard-coded string.  However, the property in the path is set by the function setProperty, then converted into a string.  The sequence of the property is not guaranteed, thus some tests can fail due to the different order of property "source" and "sourcetype". 

**Solution**
Since there are only two properties and can only form two sequences, considering two strings and asserting that the path is the same with one of them would be viable.

**Goal**
This PR proposes to increase the acceptability of the assertion function, so the test pass even if the sequence of properties in the path is different.
